### PR TITLE
Alternative Idle Handling

### DIFF
--- a/extension/js/main.js
+++ b/extension/js/main.js
@@ -205,8 +205,8 @@ function confirm_user_active(url) {
 
 var pending_url = '';
 var notification_responded = false;
-chrome.notifications.onClosed.addListener(function(id) {
-  if (id === 'verify_user' && info_hash.tester_state === 'idle' || id === 'HIT_decline_warn' && !notification_responded) {
+chrome.notifications.onClosed.addListener(function(id, user) {
+  if (id === 'verify_user' && info_hash.tester_state === 'idle' || id === 'HIT_decline_warn' && !notification_responded || user) {
     // user is idle
     set_checking(_checking_active);             
   } else if (id === 'verify_user' && info_hash.tester_state === 'active' && !notification_responded) {

--- a/extension/js/main.js
+++ b/extension/js/main.js
@@ -206,10 +206,10 @@ function confirm_user_active(url) {
 var pending_url = '';
 var notification_responded = false;
 chrome.notifications.onClosed.addListener(function(id, user) {
-  if (id === 'verify_user' && info_hash.tester_state === 'idle' || id === 'HIT_decline_warn' && !notification_responded || user) {
+  if (id === 'HIT_decline_warn' && !notification_responded || user) {
     // user is idle
     set_checking(_checking_active);             
-  } else if (id === 'verify_user' && info_hash.tester_state === 'active' && !notification_responded) {
+  } else if (id === 'verify_user' && !notification_responded) {
     chrome.notifications.create("HIT_decline_warn",{type: "basic", iconUrl: "icons/original.png", title: "HIT will be declined!", message: 'You gave no response so the HIT will be auto-declined.', contextMessage: 'Accept or do nothing to decline.', buttons: [{title: "Accept"}]});
   }
 });

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Rainforest Tester Notifier [DEV]",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "manifest_version": 2,
   "description": "Notifies Rainforest Testers when there is new work to be done.",
   "homepage_url": "https://portal.rainforestqa.com",

--- a/production_manifest.json
+++ b/production_manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Rainforest Tester Notifier",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "manifest_version": 2,
   "description": "Notifies Rainforest Testers when there is new work to be done.",
   "homepage_url": "https://portal.rainforestqa.com",

--- a/staging_manifest.json
+++ b/staging_manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Rainforest Tester Notifier [STG]",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "manifest_version": 2,
   "description": "Notifies Rainforest Testers when there is new work to be done.",
   "homepage_url": "https://portal.rnfrst.com",


### PR DESCRIPTION
Some people complained that they could be ready but considered "idle" and keep having the extension turn off on them. This PR will fix it.

Instead of just turning off after a delay, the idle handing will instead prompt the user to accept any HIT's they get if they are considered idle. If they don't accept/do nothing (2 chances to accept) the extension turns off.

Also the extension will turn off if the computer is locked or screensaver.

Note: This will break if HIT reservation is added, as it relies on HIT's not being reserved until the tab opens

[This PR was earlier closed because there was a bug, but after browser restart I couldn't reproduce it.]