### PR TITLE
fix bugs on delayed tab opening.

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -214,21 +214,29 @@ function openOrFocusTab(url) {
   if (appState.workTab === null) {
     app.makeNewWorkTab(url);
   } else {
-    app.refreshTabInfo();
+    app.refreshTabInfo(url);
   }
 }
 
-// Make sure the work tab is open and in focus
-function refreshTabInfo() {
+// Make sure the work tab is open and in focus also to ensure that new job is opened ASAP.
+function refreshTabInfo(url) {
   chrome.tabs.get(appState.workTab.id, tab => {
     if (chrome.runtime.lastError) {
       appState.workTab = null;
+      // no tab here, let start over with new tab.
+      app.makeNewWorkTab(url);
     } else {
       appState.workTab = tab;
+      
+      // check url on current tab and if not match, let start over w/ new tab
+      var re = /tester\.rainforestqa\.com\/tester\//;
+      if (!re.test(tab.url)) {
+        app.makeNewWorkTab(url);
+      }
 
-      // force selection
-      if (!appState.workTab.selected) {
-        chrome.tabs.update(appState.workTab.id, {selected: true});
+      // force focus on workTab
+      if (!appState.workTab.highlighted) {
+        chrome.tabs.update(appState.workTab.id, {highlighted: true});
       }
     }
   });


### PR DESCRIPTION
-updated workTab.selected with chrome.tabs.highlighted because chrome.tabs.selected is *Deprecated since Chrome 33
-add make new tab after chrome.tabs.get() get into error because tab not found.
-add new parameter to carry url into refreshTabInfo() to ensure creation of new tab after chrome.runtime error
-add regEx to check tab's url.  If it is on different url, let startover w/ new tab!

reason bugs?   it took 2 cycles to open a new workTab because of invalid workTab ID.  (closed tab)
     also when a worker is done w/ the job.. (the link changed) or they would type in different url and the workTab ID still in the system so we'll prefer to open new tab and start over.