### PR TITLE
Make portal pages externally connectable

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Rainforest Tester Notifier [DEV]",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "manifest_version": 2,
   "description": "Notifies Rainforest Testers when there is new work to be done.",
   "homepage_url": "https://portal.rainforestqa.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tester-chrome-extension",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "The Rainforest Chrome Extension for Testers (internal JS)",
   "main": "lib/index.js",
   "scripts": {

--- a/production_manifest.json
+++ b/production_manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Rainforest Tester Notifier",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "manifest_version": 2,
   "description": "Notifies Rainforest Testers when there is new work to be done.",
   "homepage_url": "https://portal.rainforestqa.com",
@@ -23,7 +23,7 @@
     "default_icon": "icons/icon19_grey.png"
   },
   "externally_connectable": {
-    "matches": ["*://rainforestqa.com/*"]
+    "matches": ["*://portal.rainforestqa.com/*"]
   },
   "permissions": [
     "cookies",

--- a/staging_manifest.json
+++ b/staging_manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Rainforest Tester Notifier [STG]",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "manifest_version": 2,
   "description": "Notifies Rainforest Testers when there is new work to be done.",
   "homepage_url": "https://portal.rnfrst.com",
@@ -23,7 +23,7 @@
     "default_icon": "icons/icon19_grey.png"
   },
   "externally_connectable": {
-    "matches": ["*://rnfrst.com/*"]
+    "matches": ["*://portal.rnfrst.com/*"]
   },
   "permissions": [
     "cookies",


### PR DESCRIPTION
Was preventing the auth credentials from getting sent properly.

@rainforestapp/core @ukd1