### PR TITLE
Usability improvements

### DIFF
--- a/src/chrome/__tests__/renderIcon.js
+++ b/src/chrome/__tests__/renderIcon.js
@@ -110,26 +110,28 @@ describe('renderIcon', function() {
 
   describe('badge', function() {
     describe('when the worker is working', function() {
-      it('is green and says IN P', function() {
+      it('is green and says WIP', function() {
         const store = storeWithWorkerState('working');
         const chrome = mockChrome();
 
         renderIcon(store, chrome);
 
         const badge = chrome.getBadge();
-        expect(badge.text).to.equal('WORK');
+        expect(badge.text).to.equal('WIP');
         expect(badge.color).to.equal(colors.GREEN);
       });
     });
 
     describe('when the worker is inactive', function() {
-      it('is blank', function() {
+      it('says OFF', function() {
         const store = storeWithWorkerState('inactive');
         const chrome = mockChrome();
 
         renderIcon(store, chrome);
 
-        expect(chrome.getBadge().text).to.equal('');
+        const badge = chrome.getBadge();
+        expect(badge.text).to.equal('OFF');
+        expect(badge.color).to.equal(colors.RED);
       });
     });
 

--- a/src/chrome/__tests__/startIdleChecking.js
+++ b/src/chrome/__tests__/startIdleChecking.js
@@ -13,22 +13,20 @@ import { updateWorkerState } from '../../actions';
 import { workerIdle } from '../notifications';
 
 describe('startIdleChecking', function() {
-  ['idle', 'locked'].forEach(state => {
-    it(`changes the worker state to inactive after chrome is ${state}`, function() {
-      const chrome = mockChrome();
-      const store = createStore(pluginApp);
-      store.dispatch(updateWorkerState('ready'));
+  it('changes the worker state to inactive after chrome is idle', function() {
+    const chrome = mockChrome();
+    const store = createStore(pluginApp);
+    store.dispatch(updateWorkerState('ready'));
 
-      startIdleChecking(store, chrome);
+    startIdleChecking(store, chrome);
 
-      chrome.stateChanged('active');
+    chrome.stateChanged('active');
 
-      expect(store.getState().worker.get('state')).to.equal('ready');
+    expect(store.getState().worker.get('state')).to.equal('ready');
 
-      chrome.stateChanged(state);
+    chrome.stateChanged('idle');
 
-      expect(store.getState().worker.get('state')).to.equal('inactive');
-    });
+    expect(store.getState().worker.get('state')).to.equal('inactive');
   });
 
   it('gives the worker a notification and logs them back in if they click it', function() {

--- a/src/chrome/renderIcon.js
+++ b/src/chrome/renderIcon.js
@@ -8,7 +8,11 @@ const renderIcon = (store, chrome) => {
     switch (workerState) {
       case 'working':
         chrome.browserAction.setBadgeBackgroundColor({ color: colors.GREEN });
-        chrome.browserAction.setBadgeText({ text: 'WORK' });
+        chrome.browserAction.setBadgeText({ text: 'WIP' });
+        break;
+      case 'inactive':
+        chrome.browserAction.setBadgeBackgroundColor({ color: colors.RED });
+        chrome.browserAction.setBadgeText({ text: 'OFF' });
         break;
       default:
         chrome.browserAction.setBadgeText({ text: '' });

--- a/src/chrome/startIdleChecking.js
+++ b/src/chrome/startIdleChecking.js
@@ -2,7 +2,7 @@ import { updateWorkerState } from '../actions';
 import { notifications, workerIdle } from './notifications';
 import listenStoreChanges from '../listenStoreChanges';
 
-const idlePeriod = 3 * 60;
+const idlePeriod = 6 * 60;
 
 const startIdleChecking = (store, chrome) => {
   const goIdle = () => {
@@ -23,7 +23,7 @@ const startIdleChecking = (store, chrome) => {
   chrome.idle.setDetectionInterval(idlePeriod);
 
   chrome.idle.onStateChanged.addListener(state => {
-    if (state === 'idle' || state === 'locked') {
+    if (state === 'idle') {
       goIdle();
     }
   });


### PR DESCRIPTION
- Make idle timeout 6 minutes (seems like a decent compromise for now)
- Make the badge a bit better (WIP instead of WORK, plus it says OFF
  for inactive)

Not yet implemented: automatically re-activating when coming back from
idle (will look into it tomorrow).

@rainforestapp/tester-product @ukd1