### PR TITLE
Handle idle checking when work is in progress

### DIFF
--- a/src/chrome/__tests__/startIdleChecking.js
+++ b/src/chrome/__tests__/startIdleChecking.js
@@ -29,6 +29,20 @@ describe('startIdleChecking', function() {
     expect(store.getState().worker.get('state')).to.equal('inactive');
   });
 
+  it('changes wantsMoreWork to false if the worker is working', function() {
+    const chrome = mockChrome();
+    const store = createStore(pluginApp);
+    store.dispatch(updateWorkerState('working'));
+
+    startIdleChecking(store, chrome);
+
+    chrome.stateChanged('idle');
+
+    const { worker } = store.getState();
+    expect(worker.get('state')).to.equal('working');
+    expect(worker.get('wantsMoreWork')).to.be.false;
+  });
+
   it('gives the worker a notification and logs them back in if they click it', function() {
     const chrome = mockChrome();
     const store = createStore(pluginApp);

--- a/src/chrome/startIdleChecking.js
+++ b/src/chrome/startIdleChecking.js
@@ -1,4 +1,4 @@
-import { updateWorkerState } from '../actions';
+import { updateWorkerState, iconClicked } from '../actions';
 import { notifications, workerIdle } from './notifications';
 import listenStoreChanges from '../listenStoreChanges';
 
@@ -6,12 +6,20 @@ const idlePeriod = 6 * 60;
 
 const startIdleChecking = (store, chrome) => {
   const goIdle = () => {
-    if (store.getState().worker.get('state') !== 'ready') {
-      return;
+    const { worker } = store.getState();
+    switch (worker.get('state')) {
+      case 'ready':
+        store.dispatch(updateWorkerState('inactive'));
+        chrome.notifications.create(workerIdle, notifications[workerIdle]);
+        break;
+      case 'working':
+        if (worker.get('wantsMoreWork')) {
+          // "Click icon" to indicate that the worker doesn't want more work
+          store.dispatch(iconClicked());
+        }
+        break;
+      default:
     }
-
-    store.dispatch(updateWorkerState('inactive'));
-    chrome.notifications.create(workerIdle, notifications[workerIdle]);
   };
 
   const handleUpdate = (_previousState, currentState) => {


### PR DESCRIPTION
Handles the case when the worker gets assigned a job before going idle.

@rainforestapp/tester-product @ukd1