### PR TITLE
Hard-code polling endpoint

### DIFF
--- a/src/__tests__/startErrorHandling.js
+++ b/src/__tests__/startErrorHandling.js
@@ -33,7 +33,7 @@ describe('startErrorHandling', function() {
     // Bad call to authenticate
     store.dispatch(authenticate());
 
-    expect(captureException).to.have.been.called.twice;
+    expect(captureException).to.have.been.calledThrice;
   });
 
   it("records the worker UUID when it's set", function() {

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -14,7 +14,6 @@ export const setPluginVersion = createAction(actions.SET_PLUGIN_VERSION);
 export const startPolling = createAction(actions.START_POLLING);
 export const stopPolling = createAction(actions.STOP_POLLING);
 export const setPollingInterval = createAction(actions.SET_POLLING_INTERVAL);
-export const setPollUrl = createAction(actions.SET_POLL_URL);
 export const captchaRequired = createAction(actions.CAPTCHA_REQUIRED);
 export const rateLimitExceeded = createAction(actions.RATE_LIMIT_EXCEEDED);
 export const setWorkerProfile = createAction(actions.SET_WORKER_PROFILE);

--- a/src/chrome/__tests__/getSync.js
+++ b/src/chrome/__tests__/getSync.js
@@ -27,62 +27,18 @@ describe('getSync', function() {
 
     let success = false;
     store.subscribe(() => {
-      const { worker, socket } = store.getState();
+      const { worker, socket, polling } = store.getState();
+      const expectedPollUrl = 'http://portal.rainforest.dev/api/1/testers/abc123/work_available';
       if (!success &&
           worker.get('uuid') === workerUUID &&
-          socket.get('auth').equals(fromJS(socketAuth))) {
+          socket.get('auth').equals(fromJS(socketAuth)) &&
+          polling.get('pollUrl') === expectedPollUrl) {
         success = true;
         done();
       }
     });
 
     getSync(store, chrome);
-  });
-
-  it("sets the poll URL if it's stored in sync", function(done) {
-    const workerUUID = 'abc123';
-    const storage = {
-      worker_uuid: workerUUID,
-      work_available_endpoint: 'http://work.com/',
-    };
-    const store = createStore(pluginApp);
-    const chrome = mockChrome({ storage });
-
-    let success = false;
-    store.subscribe(() => {
-      const { polling } = store.getState();
-      if (!success && polling.get('pollUrl') === 'http://work.com/abc123/work_available') {
-        success = true;
-        done();
-      }
-    });
-
-    getSync(store, chrome);
-  });
-
-  it("doesn't set the poll URL if it would be invalid", function(done) {
-    const workerUUID = 'abc123';
-    const storage = {
-      worker_uuid: workerUUID,
-      work_available_endpoint: '',
-    };
-
-    const store = createStore(pluginApp);
-    const chrome = mockChrome({ storage });
-
-    store.subscribe(() => {
-      const { polling } = store.getState();
-      if (polling.get('error')) {
-        done(polling.get('error'));
-      }
-      if (polling.get('pollUrl')) {
-        done(new Error(`pollUrl was set to ${polling.get('pollUrl')} but shouldn't have`));
-      }
-    });
-
-    getSync(store, chrome);
-
-    setTimeout(done, 50);
   });
 
   it("sets the options if they're stored in sync", function(done) {

--- a/src/chrome/__tests__/listenMessages.js
+++ b/src/chrome/__tests__/listenMessages.js
@@ -26,7 +26,6 @@ describe('listenMessages', function() {
         payload: {
           worker_uuid: 'abc123',
           websocket_auth: auth,
-          work_available_endpoint: 'http://www.work.com/',
         },
       }, spy);
     };
@@ -62,28 +61,7 @@ describe('listenMessages', function() {
       sendAuth(chrome, () => {});
 
       const pollUrl = store.getState().polling.get('pollUrl');
-      expect(pollUrl).to.equal('http://www.work.com/abc123/work_available');
-    });
-
-    it("doesn't set the polling endpoint if it's invalid", function() {
-      const store = createStore(pluginApp);
-      const chrome = mockChrome({ storage: { work_available_endpoint: 'http://work.com' } });
-      listenMessages(store, chrome);
-
-      chrome.sendRuntimeMessage({
-        type: 'AUTHENTICATE',
-        payload: {
-          worker_uuid: 'abc123',
-          websocket_auth: auth,
-          work_available_endpoint: '',
-        },
-      });
-
-      const { polling } = store.getState();
-      expect(polling.get('pollUrl')).to.be.null;
-      expect(polling.get('error')).to.be.null;
-
-      expect(chrome.getStorage().work_available_endpoint).to.equal('http://work.com');
+      expect(pollUrl).to.equal('http://portal.rainforest.dev/api/1/testers/abc123/work_available');
     });
 
     it('stores the data in the chrome sync storage', function() {
@@ -96,7 +74,6 @@ describe('listenMessages', function() {
       const storage = chrome.getStorage();
       expect(storage.worker_uuid).to.equal('abc123');
       expect(storage.websocket_auth).to.equal(auth);
-      expect(storage.work_available_endpoint).to.equal('http://www.work.com/');
     });
 
     it('responds with plugin information', function(done) {

--- a/src/chrome/getSync.js
+++ b/src/chrome/getSync.js
@@ -1,7 +1,7 @@
-import { authenticate, setOptions, setPollUrl } from '../actions';
+import { authenticate, setOptions } from '../actions';
 
 const getSync = (store, chrome) => {
-  const dataKeys = ['worker_uuid', 'websocket_auth', 'work_available_endpoint', 'options'];
+  const dataKeys = ['worker_uuid', 'websocket_auth', 'options'];
   chrome.storage.sync.get(dataKeys, data => {
     let auth = null;
     if (data.worker_uuid && data.websocket_auth) {
@@ -9,14 +9,6 @@ const getSync = (store, chrome) => {
     }
     if (auth) {
       store.dispatch(authenticate(auth));
-    }
-
-    let pollUrl = null;
-    if (data.work_available_endpoint && data.worker_uuid) {
-      pollUrl = `${data.work_available_endpoint}${data.worker_uuid}/work_available`;
-    }
-    if (pollUrl) {
-      store.dispatch(setPollUrl(pollUrl));
     }
 
     if (data.options) {

--- a/src/chrome/listenMessages.js
+++ b/src/chrome/listenMessages.js
@@ -1,11 +1,10 @@
-import { authenticate, setPollUrl, workStarted, workFinished, setOptions } from '../actions';
+import { authenticate, workStarted, workFinished, setOptions } from '../actions';
 import { logDebug } from '../logging';
 
 const listenMessages = (store, chrome) => {
   const handleAuthMessage = ({
     worker_uuid: workerUUID,
     websocket_auth: socketAuth,
-    work_available_endpoint: pollEndpoint,
   }) => {
     if (!workerUUID || !socketAuth) {
       throw new Error('Invalid authentication message received!');
@@ -17,20 +16,10 @@ const listenMessages = (store, chrome) => {
     };
     store.dispatch(authenticate(auth));
 
-    if (pollEndpoint) {
-      const pollUrl = `${pollEndpoint}${workerUUID}/work_available`;
-      store.dispatch(setPollUrl(pollUrl));
-      chrome.storage.sync.set({
-        worker_uuid: workerUUID,
-        websocket_auth: socketAuth,
-        work_available_endpoint: pollEndpoint,
-      });
-    } else {
-      chrome.storage.sync.set({
-        worker_uuid: workerUUID,
-        websocket_auth: socketAuth,
-      });
-    }
+    chrome.storage.sync.set({
+      worker_uuid: workerUUID,
+      websocket_auth: socketAuth,
+    });
   };
 
   const handleWorkError = () => {

--- a/src/constants.js
+++ b/src/constants.js
@@ -15,7 +15,6 @@ export const actions = deepFreeze({
   START_POLLING: 'START_POLLING',
   STOP_POLLING: 'STOP_POLLING',
   SET_POLLING_INTERVAL: 'SET_POLLING_INTERVAL',
-  SET_POLL_URL: 'SET_POLL_URL',
   CAPTCHA_REQUIRED: 'CAPTCHA_REQUIRED',
   SET_WORKER_PROFILE: 'SET_WORKER_PROFILE',
   RATE_LIMIT_EXCEEDED: 'RATE_LIMIT_EXCEEDED',
@@ -52,6 +51,7 @@ const getConfig = () => {
         env: 'dev',
         socketURL: 'ws://localhost:4000/socket',
         profileUrl: 'http://portal.rainforest.dev/profile',
+        workAvailableEndpoint: 'http://portal.rainforest.dev/api/1/testers',
         chrome: getChromeConfig(),
         ravenURL: 'BOGUS',
       };
@@ -60,6 +60,7 @@ const getConfig = () => {
         env: 'staging',
         socketURL: 'wss://schrute.rnfrst.com/socket',
         profileUrl: 'https://portal.rnfrst.com/profile',
+        workAvailableEndpoint: 'https://portal.rainforestqa.com/api/1/testers',
         chrome: getChromeConfig(),
         ravenURL: 'https://0f911298f80c47d9b53d3e6a53d236e5@app.getsentry.com/88435',
       };
@@ -68,6 +69,7 @@ const getConfig = () => {
         env: 'prod',
         socketURL: 'wss://schrute.rainforestqa.com/socket',
         profileUrl: 'https://portal.rainforestqa.com/profile',
+        workAvailableEndpoint: 'https://bouncer.rainforestqa.com/1/testers',
         chrome: getChromeConfig(),
         ravenURL: 'https://a7b0c76390cc47208e38b884fd60ff3d@sentry.io/68477',
       };
@@ -76,6 +78,7 @@ const getConfig = () => {
         env: 'test',
         socketURL: 'ws://localhost:4000/socket',
         profileUrl: 'http://portal.rainforest.dev/profile',
+        workAvailableEndpoint: 'http://portal.rainforest.dev/api/1/testers',
         chrome: {
           notificationIconUrl: 'bogusNotifications.png',
           greyIcon: { path: 'GREY' },

--- a/src/reducers/__tests__/polling.js
+++ b/src/reducers/__tests__/polling.js
@@ -7,10 +7,10 @@
 import chai, { expect } from 'chai';
 import { actions, DEFAULT_POLLING_INTERVAL } from '../../constants';
 import {
+  authenticate,
   startPolling,
   stopPolling,
   setPollingInterval,
-  setPollUrl,
   assignWork,
   captchaRequired,
   iconClicked,
@@ -79,23 +79,6 @@ describe('polling reducer', function() {
     });
   });
 
-  describe(actions.SET_POLL_URL, function() {
-    it('sets the URL for polling', function() {
-      const state = polling(undefined, setPollUrl('http://work.com/foo-bar'));
-      checkState(state);
-
-      expect(state.get('pollUrl')).to.equal('http://work.com/foo-bar');
-    });
-
-    it('checks for invalid URLs', function() {
-      const state = polling(undefined, setPollUrl('/foo/bar'));
-      checkState(state);
-
-      expect(state.get('pollUrl')).to.be.null;
-      expect(state.get('error')).to.be.an('error');
-    });
-  });
-
   describe(actions.ASSIGN_WORK, function() {
     it('stops polling', function() {
       let state = polling(undefined, startPolling({ url: 'http://example.com' }));
@@ -138,6 +121,25 @@ describe('polling reducer', function() {
       checkState(state);
 
       expect(state.get('interval')).to.equal(4000);
+    });
+  });
+
+  describe(actions.AUTHENTICATE, function() {
+    it('sets pollUrl', function() {
+      const auth = {
+        auth: 'SEKRET',
+        sig: 'SIG',
+      };
+      const action = authenticate({
+        workerUUID: 'abc123',
+        socketAuth: auth,
+      });
+      const state = polling(undefined, action);
+      checkState(state);
+
+      expect(state.get('pollUrl')).to.equal(
+        'http://portal.rainforest.dev/api/1/testers/abc123/work_available'
+      );
     });
   });
 });

--- a/src/reducers/polling.js
+++ b/src/reducers/polling.js
@@ -20,7 +20,7 @@ const startPolling = (state, { payload }) => {
 
 const authenticate = (state, { payload }) => {
   if (!payload) {
-    return state.set('error', new Error('authenticate dispatched without a pauload'));
+    return state.set('error', new Error('authenticate dispatched without a payload'));
   }
   const { workerUUID } = payload;
   if (!workerUUID) {

--- a/src/socket/__tests__/index.js
+++ b/src/socket/__tests__/index.js
@@ -7,7 +7,7 @@
 import chai, { expect } from 'chai';
 import { mockSocket } from '../__mocks__';
 import { createStore } from 'redux';
-import { authenticate, updateWorkerState, setPollUrl, iconClicked } from '../../actions';
+import { authenticate, updateWorkerState, iconClicked } from '../../actions';
 import pluginApp from '../../reducers';
 import { startSocket } from '..';
 import sinon from 'sinon';
@@ -165,7 +165,6 @@ describe('startSocket', function() {
     const store = createStore(pluginApp);
     const socket = authenticatedSocket(store, {});
     const channel = socket.getSocket().testChannel;
-    store.dispatch(setPollUrl('http://work.com'));
 
     channel.serverPush('start_polling', {});
 


### PR DESCRIPTION
Setting it dynamically made a lot of sense when it was hard to deploy
the extension but not so much any more. Polling will be nuked soon in
any case, so it doesn't make sense to have to deal with error-proneness
for the time being.

See #629

@rainforestapp/tester-product @ukd1