### PR TITLE
Handle state save/restore when worker is working

### DIFF
--- a/src/chrome/__tests__/handleStateSaving.js
+++ b/src/chrome/__tests__/handleStateSaving.js
@@ -8,7 +8,7 @@ import { mockChrome } from '../__mocks__/chrome';
 import { expect } from 'chai';
 import handleStateSaving from '../handleStateSaving';
 import { createStore } from 'redux';
-import { updateWorkerState } from '../../actions';
+import { updateWorkerState, iconClicked } from '../../actions';
 import pluginApp from '../../reducers';
 
 describe('handleStateSaving', function() {
@@ -20,6 +20,22 @@ describe('handleStateSaving', function() {
 
     store.dispatch(updateWorkerState('ready'));
 
+    expect(chrome.getLocalStorage().workerState).to.equal('ready');
+  });
+
+  it('saves as "ready" when the worker wants more work', function() {
+    const store = createStore(pluginApp);
+    const chrome = mockChrome();
+
+    handleStateSaving(store, chrome);
+
+    store.dispatch(updateWorkerState('working'));
+    expect(chrome.getLocalStorage().workerState).to.equal('ready');
+
+    store.dispatch(iconClicked()); // indicate worker doesn't want more work
+    expect(chrome.getLocalStorage().workerState).to.equal('inactive');
+
+    store.dispatch(iconClicked());
     expect(chrome.getLocalStorage().workerState).to.equal('ready');
   });
 

--- a/src/chrome/handleStateSaving.js
+++ b/src/chrome/handleStateSaving.js
@@ -8,9 +8,32 @@ const handleStateSaving = (store, chrome) => {
     }
   });
 
+  const shouldSaveState = (prevWorker, curWorker) => (
+    prevWorker.get('state') !== curWorker.get('state') ||
+      prevWorker.get('wantsMoreWork') !== curWorker.get('wantsMoreWork')
+  );
+
   const handleUpdate = ({ worker: prevWorker }, { worker: curWorker }) => {
-    if (prevWorker.get('state') !== curWorker.get('state')) {
-      chrome.storage.local.set({ workerState: curWorker.get('state') });
+    if (shouldSaveState(prevWorker, curWorker)) {
+      let newState;
+      switch (curWorker.get('state')) {
+        case 'working':
+          // We don't actually want to save that the worker is working, since if
+          // the "work finished" message gets lost then they could get stuck in
+          // "working" mode indefinitely. Instead we just restore to
+          // ready/inactive depending on whether the worker wants more work
+          // (double-assignment is checked on the backend so shouldn't be a
+          // problem).
+          if (curWorker.get('wantsMoreWork')) {
+            newState = 'ready';
+          } else {
+            newState = 'inactive';
+          }
+          break;
+        default:
+          newState = curWorker.get('state');
+      }
+      chrome.storage.local.set({ workerState: newState });
     }
   };
 


### PR DESCRIPTION
Previously it would always restore to "inactive" if the extension
restarted during work.

@rainforestapp/tester-product @ukd1