### PR TITLE
Ensure load order in state restoration

### DIFF
--- a/src/chrome/__tests__/handleStateSaving.js
+++ b/src/chrome/__tests__/handleStateSaving.js
@@ -41,35 +41,36 @@ describe('handleStateSaving', function() {
 
   describe('when the state has been saved from before', function() {
     describe('when the worker was ready', function() {
-      it('restores the state', function(done) {
+      it('restores the state', function() {
         const store = createStore(pluginApp);
         const chrome = mockChrome({ localStorage: { workerState: 'ready' } });
 
-        store.subscribe(() => {
-          if (store.getState().worker.get('state') === 'ready') {
-            done();
-          }
+        return new Promise((resolve, reject) => {
+          handleStateSaving(store, chrome).then(() => {
+            const workerState = store.getState().worker.get('state');
+            if (workerState !== 'ready') {
+              reject(new Error`Worker should have been ready but was ${workerState}`);
+            }
+            resolve();
+          });
         });
-
-        handleStateSaving(store, chrome);
       });
     });
 
     describe('when the worker was working', function() {
-      it("doesn't set the state", function(done) {
+      it("doesn't set the state", function() {
         const store = createStore(pluginApp);
         const chrome = mockChrome({ localStorage: { workerState: 'working' } });
 
-        setTimeout(() => {
-          const state = store.getState().worker.get('state');
-          if (state === 'inactive') {
-            done();
-          } else {
-            done(new Error(`worker should have been inactive but is ${state}`));
-          }
-        }, 20);
-
-        handleStateSaving(store, chrome);
+        return new Promise((resolve, reject) => {
+          handleStateSaving(store, chrome).then(() => {
+            const state = store.getState().worker.get('state');
+            if (state !== 'inactive') {
+              reject(new Error(`worker should have been inactive but is ${state}`));
+            }
+            resolve();
+          });
+        });
       });
     });
   });

--- a/src/chrome/getSync.js
+++ b/src/chrome/getSync.js
@@ -1,20 +1,24 @@
 import { authenticate, setOptions } from '../actions';
 
-const getSync = (store, chrome) => {
-  const dataKeys = ['worker_uuid', 'websocket_auth', 'options'];
-  chrome.storage.sync.get(dataKeys, data => {
-    let auth = null;
-    if (data.worker_uuid && data.websocket_auth) {
-      auth = { workerUUID: data.worker_uuid, socketAuth: data.websocket_auth };
-    }
-    if (auth) {
-      store.dispatch(authenticate(auth));
-    }
+const getSync = (store, chrome) => (
+  new Promise(resolve => {
+    const dataKeys = ['worker_uuid', 'websocket_auth', 'options'];
+    chrome.storage.sync.get(dataKeys, data => {
+      let auth = null;
+      if (data.worker_uuid && data.websocket_auth) {
+        auth = { workerUUID: data.worker_uuid, socketAuth: data.websocket_auth };
+      }
+      if (auth) {
+        store.dispatch(authenticate(auth));
+      }
 
-    if (data.options) {
-      store.dispatch(setOptions(data.options));
-    }
-  });
-};
+      if (data.options) {
+        store.dispatch(setOptions(data.options));
+      }
+
+      resolve();
+    });
+  })
+);
 
 export default getSync;

--- a/src/chrome/handleStateSaving.js
+++ b/src/chrome/handleStateSaving.js
@@ -2,12 +2,6 @@ import { updateWorkerState } from '../actions';
 import listenStoreChanges from '../listenStoreChanges';
 
 const handleStateSaving = (store, chrome) => {
-  chrome.storage.local.get(['workerState'], data => {
-    if (data.workerState === 'ready') {
-      store.dispatch(updateWorkerState(data.workerState));
-    }
-  });
-
   const shouldSaveState = (prevWorker, curWorker) => (
     prevWorker.get('state') !== curWorker.get('state') ||
       prevWorker.get('wantsMoreWork') !== curWorker.get('wantsMoreWork')
@@ -38,6 +32,15 @@ const handleStateSaving = (store, chrome) => {
   };
 
   listenStoreChanges(store, handleUpdate);
+
+  return new Promise(resolve => {
+    chrome.storage.local.get(['workerState'], data => {
+      if (data.workerState === 'ready') {
+        store.dispatch(updateWorkerState(data.workerState));
+      }
+      resolve();
+    });
+  });
 };
 
 export default handleStateSaving;

--- a/src/chrome/index.js
+++ b/src/chrome/index.js
@@ -28,15 +28,17 @@ export const startChromePlugin = (chrome, socketConstructor = Socket) => {
     }
   };
 
-  getSync(store, chrome);
-  handleStateSaving(store, chrome);
-  listenMessages(store, chrome);
-  handleStateNotifications(store, chrome);
-  renderIcon(store, chrome);
-  handleWork(store, chrome);
-  startIdleChecking(store, chrome);
-  getUserInfo();
-  handleCaptcha(store, chrome);
+  getSync(store, chrome)
+    .then(() => handleStateSaving(store, chrome))
+    .then(() => {
+      listenMessages(store, chrome);
+      handleStateNotifications(store, chrome);
+      renderIcon(store, chrome);
+      handleWork(store, chrome);
+      startIdleChecking(store, chrome);
+      getUserInfo();
+      handleCaptcha(store, chrome);
+    });
 
   return { getStore };
 };


### PR DESCRIPTION
The local storage (which stores worker state) was coming back before the
sync storage (which stores authentication) in some circumstances. That
led to trying to set the worker state to ready before authenticating,
which doesn't work (it puts the worker back to inactive). Promisifying
the storage handlers should fix the issue.

@rainforestapp/tester-product @ukd1