### PR TITLE
Disconnect socket after leaving channel

### DIFF
--- a/src/chrome/notifications.js
+++ b/src/chrome/notifications.js
@@ -21,7 +21,7 @@ export const notifications = deepFreeze({
     type: 'basic',
     title: 'You have been disconnected',
     message: 'You have disconnected, probably because you logged in on another computer. ' +
-      'Double-click the icon to reconnect.',
+      'Click the extension icon to reconnect.',
   },
   [workerIdle]: {
     iconUrl: CONFIG.chrome.notificationIconUrl,

--- a/src/socket/__mocks__/index.js
+++ b/src/socket/__mocks__/index.js
@@ -4,10 +4,14 @@ export const mockSocket = (opts = {}) => (
       this.endpoint = endpoint;
       this.opts = sockOpts;
       this.testChannels = {};
+      this.disconnected = false;
     }
 
     connect() { return this; }
-    disconnect() { return this; }
+    disconnect() {
+      this.disconnected = true;
+      return this;
+    }
     onClose() { return this; }
     channel(name) {
       this.testChannels[name] = {

--- a/src/socket/__tests__/index.js
+++ b/src/socket/__tests__/index.js
@@ -177,7 +177,7 @@ describe('startSocket', function() {
   });
 
   describe('receiving a leave instruction', function() {
-    it('leaves the channel', function() {
+    it('leaves the channel and disconnects', function() {
       const store = createStore(pluginApp);
       store.dispatch(updateWorkerState('ready'));
       const socket = authenticatedSocket(store, {});
@@ -187,6 +187,7 @@ describe('startSocket', function() {
 
       expect(store.getState().socket.get('state')).to.equal('left');
       expect(channel.getState()).to.equal('disconnected');
+      expect(socket.getSocket().disconnected).to.be.true;
     });
   });
 

--- a/src/socket/index.js
+++ b/src/socket/index.js
@@ -65,6 +65,7 @@ export const startSocket = (store, socketConstructor = Socket) => {
     channel.leave();
     channel = null;
     store.dispatch(channelLeft());
+    socket.disconnect();
   };
 
   const joinLobby = () => {


### PR DESCRIPTION
Previously, the socket connection remained open even though no channels
were open. This probably contributed to the DDoS-like nature of the
["infinite connection"
outage](https://paper.dropbox.com/doc/20161013-High-Error-rate-on-WorkPusher.push_batch-vBTcxGDMplKamRgKA0rd1). Now,
rogue connections will at least be short-lived since they'll disconnect
quite quickly.

@rainforestapp/tester-product @ukd1