### PR TITLE
saving reload state in local storage

### DIFF
--- a/src/chrome/__mocks__/chrome.js
+++ b/src/chrome/__mocks__/chrome.js
@@ -70,8 +70,10 @@ export const mockChrome = (opts = {}) => {
       },
     },
     local: {
-      set: (data) => {
+      set: (data, callback) => {
+        const safeCallback = typeof callback === 'function' ? callback : () => {};
         localStorageStore = Object.assign({}, localStorageStore, data);
+        safeCallback();
       },
       get: (keys, callback) => {
         setTimeout(() => {

--- a/src/chrome/__tests__/handleStateSaving.js
+++ b/src/chrome/__tests__/handleStateSaving.js
@@ -40,16 +40,16 @@ describe('handleStateSaving', function() {
   });
 
   describe('when the state has been saved from before', function() {
-    describe('when the worker was ready', function() {
+    describe('when the worker was ready before reloading', function() {
       it('restores the state', function() {
         const store = createStore(pluginApp);
-        const chrome = mockChrome({ localStorage: { workerState: 'ready' } });
+        const chrome = mockChrome({ localStorage: { workerState: 'ready', reload: true } });
 
         return new Promise((resolve, reject) => {
           handleStateSaving(store, chrome).then(() => {
             const workerState = store.getState().worker.get('state');
             if (workerState !== 'ready') {
-              reject(new Error`Worker should have been ready but was ${workerState}`);
+              reject(new Error(`Worker should have been ready but was ${workerState}`));
             }
             resolve();
           });
@@ -57,10 +57,10 @@ describe('handleStateSaving', function() {
       });
     });
 
-    describe('when the worker was working', function() {
+    describe('when the worker was working before reloading', function() {
       it("doesn't set the state", function() {
         const store = createStore(pluginApp);
-        const chrome = mockChrome({ localStorage: { workerState: 'working' } });
+        const chrome = mockChrome({ localStorage: { workerState: 'working', reload: true } });
 
         return new Promise((resolve, reject) => {
           handleStateSaving(store, chrome).then(() => {
@@ -69,6 +69,23 @@ describe('handleStateSaving', function() {
               reject(new Error(`worker should have been inactive but is ${state}`));
             }
             resolve();
+          });
+        });
+      });
+
+      describe('default worker state at startup', function() {
+        it("doesn't set the state from localStorage", function() {
+          const store = createStore(pluginApp);
+          const chrome = mockChrome({ localStorage: { workerState: 'ready', reload: false } });
+
+          return new Promise((resolve, reject) => {
+            handleStateSaving(store, chrome).then(() => {
+              const state = store.getState().worker.get('state');
+              if (state !== 'inactive') {
+                reject(new Error(`worker should have been inactive but is ${state}`));
+              }
+              resolve();
+            });
           });
         });
       });

--- a/src/chrome/handleStateSaving.js
+++ b/src/chrome/handleStateSaving.js
@@ -38,8 +38,7 @@ const handleStateSaving = (store, chrome) => {
       if (data.reload && data.workerState === 'ready') {
         store.dispatch(updateWorkerState(data.workerState));
       }
-      chrome.storage.local.set({ reload: false });
-      resolve();
+      chrome.storage.local.set({ reload: false }, resolve);
     });
   });
 };

--- a/src/chrome/handleStateSaving.js
+++ b/src/chrome/handleStateSaving.js
@@ -34,10 +34,11 @@ const handleStateSaving = (store, chrome) => {
   listenStoreChanges(store, handleUpdate);
 
   return new Promise(resolve => {
-    chrome.storage.local.get(['workerState'], data => {
-      if (data.workerState === 'ready') {
+    chrome.storage.local.get(['workerState', 'reload'], data => {
+      if (data.reload && data.workerState === 'ready') {
         store.dispatch(updateWorkerState(data.workerState));
       }
+      chrome.storage.local.set({ reload: false });
       resolve();
     });
   });

--- a/src/chrome/index.js
+++ b/src/chrome/index.js
@@ -13,7 +13,10 @@ import { applyMiddleware } from 'redux';
 import { logMiddleware } from '../logging';
 
 export const startChromePlugin = (chrome, socketConstructor = Socket) => {
-  const reloader = () => window.location.reload(true);
+  const reloader = () => {
+    chrome.storage.local.set({ reload: true });
+    window.location.reload(true);
+  };
   const enhancer = applyMiddleware(logMiddleware);
   const plugin = startPlugin({ enhancer, reloader, socketConstructor });
   const store = plugin.getStore();

--- a/src/chrome/index.js
+++ b/src/chrome/index.js
@@ -14,8 +14,9 @@ import { logMiddleware } from '../logging';
 
 export const startChromePlugin = (chrome, socketConstructor = Socket) => {
   const reloader = () => {
-    chrome.storage.local.set({ reload: true });
-    window.location.reload(true);
+    chrome.storage.local.set({ reload: true }, () => {
+      window.location.reload(true);
+    });
   };
   const enhancer = applyMiddleware(logMiddleware);
   const plugin = startPlugin({ enhancer, reloader, socketConstructor });


### PR DESCRIPTION
this allow extension to know whenever to set workerState during reload or not.   So that way, extension will always load default state at startup.

closes https://github.com/rainforestapp/tester-chrome-extension/issues/720