### PR TITLE
Manually reconnect after auto-reconnect timeout

### DIFF
--- a/src/socket/__mocks__/index.js
+++ b/src/socket/__mocks__/index.js
@@ -5,6 +5,7 @@ export const mockSocket = (opts = {}) => (
       this.opts = sockOpts;
       this.testChannels = {};
       this.disconnected = false;
+      this.onCloseCallbacks = [];
     }
 
     connect() { return this; }
@@ -12,7 +13,10 @@ export const mockSocket = (opts = {}) => (
       this.disconnected = true;
       return this;
     }
-    onClose() { return this; }
+    onClose(callback) {
+      this.onCloseCallbacks.push(callback);
+      return this;
+    }
     channel(name) {
       this.testChannels[name] = {
         onCallbacks: {},
@@ -55,6 +59,12 @@ export const mockSocket = (opts = {}) => (
         },
       };
       return this.testChannels[name];
+    }
+
+    // Simulate server disconnection for testing purposes
+    serverDisconnect() {
+      this.onCloseCallbacks.forEach(callback => callback());
+      this.disconnected = true;
     }
   }
 );


### PR DESCRIPTION
I haven't been able to reproduce "re-connection failures" (where the
plugin stops trying to reconnect), but apparently a few people are
experiencing them. This provides a manual fallback that's better than
hard-resetting the extension.

Fixes #706

@rainforestapp/tester-product @ukd1