### PR TITLE
Respond to 'already_ready' socket message

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -103,4 +103,8 @@ export const NOTIFICATIONS = deepFreeze({
     message: 'You seem to have been idle for a while, so we stopped ' +
       'checking for work. Click here to start checking for work again.',
   },
+  doubleReady: {
+    title: 'You are active on another computer',
+    message: 'Please turn off your extension elsewhere before turning it on here.',
+  },
 });

--- a/src/socket/__mocks__/index.js
+++ b/src/socket/__mocks__/index.js
@@ -28,20 +28,23 @@ export const mockSocket = (opts = {}) => (
           this.state = 'disconnected';
           return this;
         },
-        receive(code, callback) {
-          if (opts.joinReply === code) {
+        receive(event, callback) {
+          if (opts.joinReply === event) {
             callback();
           }
+          this.onCallbacks[event] = callback;
 
           return this;
         },
-        push: (event, payload) => {
+        push(event, payload) {
           if (opts.pushCallback !== undefined) {
             opts.pushCallback(event, payload);
           }
-          if (this.opts.logger !== undefined) {
-            this.opts.logger('fake_send', event, payload);
+          if (opts.logger !== undefined) {
+            opts.logger('fake_send', event, payload);
           }
+
+          return this;
         },
         on(event, callback) {
           this.onCallbacks[event] = callback;

--- a/src/socket/__tests__/index.js
+++ b/src/socket/__tests__/index.js
@@ -191,6 +191,21 @@ describe('startSocket', function() {
         );
       });
     });
+
+    describe('when the worker is ready on another computer', function() {
+      it('makes the worker inactive and makes a notification', function() {
+        const store = createStore(pluginApp);
+        const channel = authenticatedSocket(store, {}).getSocket().testChannels[channelName];
+
+        store.dispatch(updateWorkerState('ready'));
+        // simulate reply
+        channel.serverPush('already_ready');
+
+        const { worker, notifications } = store.getState();
+        expect(worker.get('state')).to.equal('inactive');
+        expect(notifications.get('activeNotifications').includes('doubleReady')).to.be.true;
+      });
+    });
   });
 
   describe('receiving a leave instruction', function() {

--- a/src/socket/index.js
+++ b/src/socket/index.js
@@ -12,6 +12,8 @@ import {
   setPluginVersion,
   channelLeft,
   reloadPlugin,
+  updateWorkerState,
+  notify,
 } from '../actions';
 
 const AUTO_RECONNECT_TIMEOUT = 60 * 1000;
@@ -27,7 +29,11 @@ export const startSocket = (store, socketConstructor = Socket) => {
       return;
     }
 
-    channel.push('update_state', { worker_state: state });
+    channel.push('update_state', { worker_state: state })
+      .receive('already_ready', () => {
+        store.dispatch(updateWorkerState('inactive'));
+        store.dispatch(notify('doubleReady'));
+      });
   };
 
   const workerState = () => store.getState().worker.get('state');


### PR DESCRIPTION
This should improve "uniqueness" checking—before, we kicked old
connections off when someone joined twice; now they will both be
connected/tracked but only one can be "ready" at any given time.

See rainforestapp/schrute#94

@rainforestapp/tester-product @ukd1 