### PR TITLE
Retry "ready" state updates

### DIFF
--- a/src/socket/index.js
+++ b/src/socket/index.js
@@ -1,4 +1,5 @@
 import { Socket } from 'phoenix';
+import Raven from 'raven-js';
 import listenStoreChanges from '../listenStoreChanges';
 import { logDebug } from '../logging';
 import { CONFIG } from '../constants';
@@ -17,22 +18,59 @@ import {
 } from '../actions';
 
 const AUTO_RECONNECT_TIMEOUT = 60 * 1000;
+const READY_RETRY_TIMEOUT = 60 * 1000;
+const READY_RETRY_PERIOD = 10 * 1000;
 
 export const startSocket = (store, socketConstructor = Socket) => {
   let socket = null;
   let channel = null;
   let disconnectedAt = null;
+  let readyRetryStartedAt = null;
+  let readyRetryTimer = null;
 
-  const pushWorkerState = (state) => {
+  const clearReadyRetry = () => {
+    clearTimeout(readyRetryTimer);
+    readyRetryStartedAt = null;
+    readyRetryTimer = null;
+  };
+
+  const pushWorkerState = (state, retryOnFail = false) => {
     if (!channel) {
       // Channel hasn't been joined, but it's OK.
       return;
     }
 
+    if (!retryOnFail && readyRetryTimer) {
+      // There was a previous attempt at automatically retrying; cancel it
+      // because we manually changed state.
+      clearReadyRetry();
+    }
+
     channel.push('update_state', { worker_state: state })
       .receive('already_ready', () => {
-        store.dispatch(updateWorkerState('inactive'));
-        store.dispatch(notify('doubleReady'));
+        if (retryOnFail) {
+          // In this case, we're automatically reconnecting so it's unlikely
+          // that there are actually multiple connections and more likely that
+          // there's a "zombie" connection on the server. So we retry for a
+          // while (long enough for zombie connections to timeout) and then move
+          // to "inactive" without a notification.
+          if (!readyRetryStartedAt) {
+            readyRetryStartedAt = Date.now();
+          }
+          if (Date.now() - readyRetryStartedAt > READY_RETRY_TIMEOUT) {
+            const uuid = store.getState().worker.get('uuid');
+            Raven.captureException(new Error('Worker timed out moving to "ready" state'), {
+              extra: { worker_uuid: uuid },
+            });
+            clearReadyRetry();
+            store.dispatch(updateWorkerState('inactive'));
+          } else {
+            readyRetryTimer = setTimeout(() => pushWorkerState('ready', true), READY_RETRY_PERIOD);
+          }
+        } else {
+          store.dispatch(updateWorkerState('inactive'));
+          store.dispatch(notify('doubleReady'));
+        }
       });
   };
 
@@ -106,6 +144,7 @@ export const startSocket = (store, socketConstructor = Socket) => {
     });
     socket.onClose(() => {
       disconnectedAt = Date.now();
+      clearReadyRetry();
       store.dispatch(connectionClosed());
     });
     socket.connect();
@@ -119,7 +158,7 @@ export const startSocket = (store, socketConstructor = Socket) => {
     channel.join()
       .receive('ok', resp => {
         disconnectedAt = null;
-        pushWorkerState(workerState());
+        pushWorkerState(workerState(), true);
         store.dispatch(connect(resp));
         // We only want to join the lobby if the actual channel connection was
         // successful


### PR DESCRIPTION
When the extension automatically reconnects after a connection failure, it sends
its current state to the server. However, it seems that under certain
circumstances the server will keep around a "zombie" connection (that could be
"ready") until it times out, so the new connection can't move to "ready" until
the old connection clears (since we enforce that only one connection can be
"ready" per worker). In this case, it makes sense to retry for a while instead
of alerting the user. (Manual state updates won't retry under any
circumstances.)

My only concern is that this introduces a mismatch between the extension state
and the server state, which could be hard to debug if something goes wrong. But
I can't think of a better alternative.

Fixes #752

@rainforestapp/tester-product @ukd1