### PR TITLE
Optionally confirm work assignment

### DIFF
--- a/src/chrome/__mocks__/chrome.js
+++ b/src/chrome/__mocks__/chrome.js
@@ -185,9 +185,12 @@ export const mockChrome = (opts = {}) => {
 
   const getCurrentNotifications = () => currentNotifications;
   const clickNotification = (notificationId) => {
-    notificationListeners.forEach(listener => {
-      listener(notificationId);
-    });
+    if (currentNotifications[notificationId] &&
+        currentNotifications[notificationId].isClickable) {
+      notificationListeners.forEach(listener => {
+        listener(notificationId);
+      });
+    }
   };
   const closeNotification = (notificationId) => {
     notificationClosedListeners.forEach(listener => {

--- a/src/chrome/__tests__/handleWork.js
+++ b/src/chrome/__tests__/handleWork.js
@@ -7,8 +7,10 @@
 
 import { mockChrome } from '../__mocks__/chrome';
 import { expect } from 'chai';
+import sinon from 'sinon';
 import {
   assignWork,
+  setOptions,
   updateWorkerState,
   workStarted,
   workFinished,
@@ -16,22 +18,70 @@ import {
 import { createStore } from 'redux';
 import pluginApp from '../../reducers';
 import handleWork from '../handleWork';
+import handleNotifications from '../handleNotifications';
 
 describe('handleWork', function() {
   describe('when work is assigned', function() {
-    it('opens a tab with the work', function() {
-      const store = createStore(pluginApp);
-      const chrome = mockChrome();
-      store.dispatch(updateWorkerState('ready'));
+    describe('without work confirmation enabled', function() {
+      it('opens a tab with the work', function() {
+        const store = createStore(pluginApp);
+        const chrome = mockChrome();
+        store.dispatch(updateWorkerState('ready'));
 
-      handleWork(store, chrome);
+        handleWork(store, chrome);
 
-      const url = 'http://www.example.com';
-      store.dispatch(assignWork({ url }));
+        const url = 'http://www.example.com';
+        store.dispatch(assignWork({ url }));
 
-      const tabs = chrome.getOpenTabs();
-      expect(tabs.length).to.equal(1);
-      expect(tabs[0].url).to.equal(url);
+        const tabs = chrome.getOpenTabs();
+        expect(tabs.length).to.equal(1);
+        expect(tabs[0].url).to.equal(url);
+      });
+    });
+
+    describe('with work confirmation enabled', function() {
+      it("shows a notification and then assigns the work if it's clicked", function() {
+        const store = createStore(pluginApp);
+        const chrome = mockChrome();
+        store.dispatch(updateWorkerState('ready'));
+        store.dispatch(setOptions({ confirmWorkAssignment: true }));
+
+        handleWork(store, chrome);
+        handleNotifications(store, chrome);
+
+        const url = 'http://www.example.com';
+        store.dispatch(assignWork({ url }));
+
+        expect(chrome.getOpenTabs().length).to.equal(0);
+        const openNotifications = store.getState().notifications.get('activeNotifications');
+        expect(openNotifications.includes('workAssigned')).to.be.true;
+
+        chrome.clickNotification('workAssigned');
+        const tabs = chrome.getOpenTabs();
+        expect(tabs.length).to.equal(1);
+        expect(tabs[0].url).to.equal(url);
+      });
+
+      it('times out after 30 seconds', function() {
+        const clock = sinon.useFakeTimers(1);
+        const store = createStore(pluginApp);
+        const chrome = mockChrome();
+        store.dispatch(updateWorkerState('ready'));
+        store.dispatch(setOptions({ confirmWorkAssignment: true }));
+
+        handleWork(store, chrome);
+
+        const url = 'http://www.example.com';
+        store.dispatch(assignWork({ url }));
+
+        clock.tick(31000);
+
+        const openNotifications = store.getState().notifications.get('activeNotifications');
+        expect(openNotifications.includes('workAssigned')).to.be.false;
+        expect(store.getState().worker.get('state')).to.eq('inactive');
+
+        clock.restore();
+      });
     });
   });
 

--- a/src/chrome/handleWork.js
+++ b/src/chrome/handleWork.js
@@ -1,9 +1,35 @@
 import listenStoreChanges from '../listenStoreChanges';
-import { workFinished } from '../actions';
+import { workFinished, updateWorkerState, notify, clearNotification } from '../actions';
 import { playSound } from '../playSound';
+
+const WORK_NOTIFICATION_TIMEOUT = 30 * 1000;
 
 const handleWork = (store, chrome) => {
   let workTabId = null;
+  let notificationTimer = null;
+
+  const shouldConfirmWorkAssignment = () => (
+    store.getState().plugin.getIn(['options', 'confirmWorkAssignment'])
+  );
+
+  const assignWork = (url) => {
+    const oldWorkTabId = workTabId;
+    chrome.tabs.create({ url }, tab => {
+      workTabId = tab.id;
+    });
+    if (oldWorkTabId) {
+      chrome.tabs.remove(oldWorkTabId);
+    }
+  };
+
+  const showConfirmationNotification = () => {
+    store.dispatch(notify('workAssigned'));
+    notificationTimer = setTimeout(() => {
+      store.dispatch(clearNotification('workAssigned'));
+      store.dispatch(updateWorkerState('inactive'));
+      notificationTimer = null;
+    }, WORK_NOTIFICATION_TIMEOUT);
+  };
 
   const handleAssignWork = ({ worker: prevWorker }, { worker: curWorker }) => {
     if (prevWorker.get('state') !== 'working' && curWorker.get('state') === 'working') {
@@ -14,13 +40,11 @@ const handleWork = (store, chrome) => {
         return;
       }
 
-      const oldWorkTabId = workTabId;
-      chrome.tabs.create({ url }, tab => {
-        workTabId = tab.id;
-        playSound(store.getState().plugin.get('options'));
-      });
-      if (oldWorkTabId) {
-        chrome.tabs.remove(oldWorkTabId);
+      playSound(store.getState().plugin.get('options'));
+      if (shouldConfirmWorkAssignment()) {
+        showConfirmationNotification(url);
+      } else {
+        assignWork(url);
       }
     }
   };
@@ -40,6 +64,21 @@ const handleWork = (store, chrome) => {
   chrome.tabs.onRemoved.addListener(tabId => {
     if (tabId === workTabId) {
       workTabClosed();
+    }
+  });
+
+  chrome.notifications.onClicked.addListener(notificationId => {
+    const { worker } = store.getState();
+    if (notificationId === 'workAssigned' && worker.get('state') === 'working') {
+      const url = worker.get('workUrl');
+      if (!url) {
+        throw new Error('Worker got notified of work without a valid URL!');
+      }
+
+      store.dispatch(clearNotification('workAssigned'));
+      clearTimeout(notificationTimer);
+      notificationTimer = null;
+      assignWork(url);
     }
   });
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -108,4 +108,10 @@ export const NOTIFICATIONS = deepFreeze({
     title: 'You are active on another computer',
     message: 'Please turn off your extension elsewhere before turning it on here.',
   },
+  workAssigned: {
+    title: 'Work is ready!',
+    message: 'Click here to begin working!',
+    isClickable: true,
+    requireInteraction: true,
+  },
 });


### PR DESCRIPTION
This should cut back on accidental work assignments that time
out. There's a 30 second confirmation period, and the job will be
reassigned after 1 minute.

See #742 (requires an option setting to work properly)

@rainforestapp/tester-product @ukd1