### PR TITLE
Handle work assignment when no window is open

### DIFF
--- a/src/chrome/__mocks__/chrome.js
+++ b/src/chrome/__mocks__/chrome.js
@@ -163,11 +163,11 @@ export const mockChrome = (opts = {}) => {
         id: tabCounter++,
       });
       openTabs.push(tab);
-      const window = { tabs: [tab] };
-      openWindows.push(window);
+      const windowSpec = { tabs: [tab] };
+      openWindows.push(windowSpec);
       setTimeout(() => {
         if (callback) {
-          callback(window);
+          callback(windowSpec);
         }
       });
     },
@@ -252,7 +252,7 @@ export const mockChrome = (opts = {}) => {
 
   const getOpenTabs = () => openTabs;
 
-  const closeWindow = () => {
+  const closeWindows = () => {
     openWindows = [];
   };
 
@@ -283,7 +283,7 @@ export const mockChrome = (opts = {}) => {
     getCurrentNotifications,
     clickNotification,
     closeNotification,
-    closeWindow,
+    closeWindows,
     clickIcon,
     getBadge,
     getOpenTabs,

--- a/src/chrome/__mocks__/chrome.js
+++ b/src/chrome/__mocks__/chrome.js
@@ -9,6 +9,7 @@ export const mockChrome = (opts = {}) => {
   const stateChangedListeners = [];
   const badge = { color: null, text: '' };
   const openTabs = [];
+  let openWindows = [{ tabs: [] }];
   let tabCounter = 42;
   const tabOnRemoveListeners = [];
   const profileUserInfo = opts.profileUserInfo || {
@@ -151,6 +152,27 @@ export const mockChrome = (opts = {}) => {
     },
   };
 
+  const windows = {
+    getAll: (callback) => {
+      // This should really be async, but it complicates the tests horribly
+      callback(openWindows);
+    },
+
+    create: (tabSpec, callback) => {
+      const tab = Object.assign({}, tabSpec, {
+        id: tabCounter++,
+      });
+      openTabs.push(tab);
+      const window = { tabs: [tab] };
+      openWindows.push(window);
+      setTimeout(() => {
+        if (callback) {
+          callback(window);
+        }
+      });
+    },
+  };
+
   const idle = {
     setDetectionInterval: () => {},
     onStateChanged: {
@@ -230,6 +252,10 @@ export const mockChrome = (opts = {}) => {
 
   const getOpenTabs = () => openTabs;
 
+  const closeWindow = () => {
+    openWindows = [];
+  };
+
   const getIcon = () => currentIcon;
 
   const getCreatedMenus = () => createdMenus;
@@ -243,6 +269,7 @@ export const mockChrome = (opts = {}) => {
     runtime,
     storage,
     tabs,
+    windows,
     browserAction,
     idle,
     identity,
@@ -256,6 +283,7 @@ export const mockChrome = (opts = {}) => {
     getCurrentNotifications,
     clickNotification,
     closeNotification,
+    closeWindow,
     clickIcon,
     getBadge,
     getOpenTabs,

--- a/src/chrome/__tests__/handleWork.js
+++ b/src/chrome/__tests__/handleWork.js
@@ -39,6 +39,25 @@ describe('handleWork', function() {
       });
     });
 
+    describe('when the main window is closed', function() {
+      it('opens a new window', function() {
+        const store = createStore(pluginApp);
+        const chrome = mockChrome();
+        store.dispatch(updateWorkerState('ready'));
+
+        handleWork(store, chrome);
+        chrome.closeWindow();
+
+        const url = 'http://www.example.com';
+
+        store.dispatch(assignWork({ url }));
+
+        const tabs = chrome.getOpenTabs();
+        expect(tabs.length).to.equal(1);
+        expect(tabs[0].url).to.equal(url);
+      });
+    });
+
     describe('with work confirmation enabled', function() {
       it("shows a notification and then assigns the work if it's clicked", function() {
         const store = createStore(pluginApp);

--- a/src/chrome/__tests__/handleWork.js
+++ b/src/chrome/__tests__/handleWork.js
@@ -46,7 +46,7 @@ describe('handleWork', function() {
         store.dispatch(updateWorkerState('ready'));
 
         handleWork(store, chrome);
-        chrome.closeWindow();
+        chrome.closeWindows();
 
         const url = 'http://www.example.com';
 

--- a/src/chrome/handleWork.js
+++ b/src/chrome/handleWork.js
@@ -14,12 +14,20 @@ const handleWork = (store, chrome) => {
 
   const assignWork = (url) => {
     const oldWorkTabId = workTabId;
-    chrome.tabs.create({ url }, tab => {
-      workTabId = tab.id;
+    chrome.windows.getAll(windows => {
+      if (windows.length >= 1) {
+        chrome.tabs.create({ url }, tab => {
+          workTabId = tab.id;
+        });
+      } else {
+        chrome.windows.create({ url }, window => {
+          workTabId = window.tabs[0].id;
+        });
+      }
+      if (oldWorkTabId) {
+        chrome.tabs.remove(oldWorkTabId);
+      }
     });
-    if (oldWorkTabId) {
-      chrome.tabs.remove(oldWorkTabId);
-    }
   };
 
   const showConfirmationNotification = () => {


### PR DESCRIPTION
This can happen if there are multiple profiles but no windows open for one
profile (oddly, Chrome keeps the extension running in the closed profile).

Fixes #776

@rainforestapp/tester-product @ukd1