### PR TITLE
RF-17228 Update Phoenix to 1.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6973,9 +6973,9 @@
       "dev": true
     },
     "phoenix": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/phoenix/-/phoenix-1.3.4.tgz",
-      "integrity": "sha512-Hn+LgWbBs/jd8VxbfsapoVUO8z8YSf0rHj4GtDm60V6u8kJLMdLAdyGdIvz9EPZvHQ4MMonbsqqjDwlSGoUDtw=="
+      "version": "1.4.13",
+      "resolved": "https://registry.npmjs.org/phoenix/-/phoenix-1.4.13.tgz",
+      "integrity": "sha512-1VYlHaifJgMvNX+gQCyB0SOdUydrdpPmrzmTs5OGanJOsOIA5lP3iL2t+MdUhrgKtEtJpnE/KRVCIa5M5itNUQ=="
     },
     "picomatch": {
       "version": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   "dependencies": {
     "deep-freeze": "0.0.1",
     "immutable": "3.8.1",
-    "phoenix": "1.3.4",
+    "phoenix": "^1.4.0",
     "raven-js": "3.7.0",
     "redux": "3.5.2",
     "redux-actions": "0.10.1"


### PR DESCRIPTION
Tested locally and it seems to be fine.

To be merged once https://github.com/rainforestapp/schrute/pull/180 is merged (the backend upgrade seems to be backward compatible with the 1.3 frontend, but not sure about the reverse).