### PR TITLE
fix circle production deploy step putting artifact zip in the wrong path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,7 +175,7 @@ jobs:
           command: mv production_manifest.json extension/manifest.json
       - run:
           name: Zip extension
-          command: cd extension && mkdir /tmp/extension && zip -r extension-$CIRCLE_SHA1.zip . -x *.git* -x circle.yml -x *.DS_Store*
+          command: cd extension && mkdir /tmp/extension && zip -r /tmp/extension/extension-$CIRCLE_SHA1.zip . -x *.git* -x circle.yml -x *.DS_Store*
       - store_artifacts:
           path: /tmp/extension
 


### PR DESCRIPTION
The circle yml has been misconfigured since it we migrated it [2 years ago](https://github.com/rainforestapp/tester-chrome-extension/commit/7d057a4559584142897abe1b34a8e57add577db4). The reason it hasn't been caught until now is because the last time we had to publish an update was [4 years ago](https://github.com/rainforestapp/tester-chrome-extension/commit/b73eb656380db78ae87336c76d8700b6a1b5d8be)...