### PR TITLE
RF-24279 remove unecessary tabs permission

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Rainforest Tester Notifier [DEV]",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "manifest_version": 2,
   "description": "Notifies Rainforest Testers when there is new work to be done.",
   "homepage_url": "https://portal.rainforestqa.com",
@@ -32,7 +32,6 @@
   "permissions": [
     "idle",
     "notifications",
-    "tabs",
     "storage",
     "contextMenus",
     "*://*.getsentry.com/*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tester-chrome-extension",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "The Rainforest Chrome Extension for Testers (internal JS)",
   "main": "src/index.js",
   "scripts": {

--- a/production_manifest.json
+++ b/production_manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Rainforest Tester Notifier",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "manifest_version": 2,
   "description": "Notifies Rainforest Testers when there is new work to be done.",
   "homepage_url": "https://portal.rainforestqa.com",
@@ -30,7 +30,6 @@
   "permissions": [
     "idle",
     "notifications",
-    "tabs",
     "storage",
     "contextMenus",
     "*://*.getsentry.com/*",

--- a/staging_manifest.json
+++ b/staging_manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Rainforest Tester Notifier [STG]",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "manifest_version": 2,
   "description": "Notifies Rainforest Testers when there is new work to be done.",
   "homepage_url": "https://portal.rnfrst.com",
@@ -31,7 +31,6 @@
   "permissions": [
     "idle",
     "notifications",
-    "tabs",
     "storage",
     "contextMenus",
     "*://*.getsentry.com/*",


### PR DESCRIPTION
the `tabs` permission is only required if we are trying to read `url`, `pendingUrl`, `title`, or `favIconUrl` properties of a tab. We only use the tab creation and removal api, and only read the tab's id so the permission isn't needed.

see https://developer.chrome.com/docs/extensions/reference/tabs/#manifest